### PR TITLE
Change rabbit variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ install:
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
 
   # Install required ansible roles
-  - ansible-galaxy install dguerri.openstack-keystone,2.0.1
-  - ansible-galaxy install dguerri.openstack-nova_conductor,2.0.0
-  - ansible-galaxy install dguerri.openstack-glance,2.0.1
-  - ansible-galaxy install dguerri.openstack-nova_api,2.0.0
+  - git clone --depth=1 https://github.com/openstack-ansible-galaxy/openstack-keystone.git ../openstack-keystone
+  - git clone --depth=1 https://github.com/openstack-ansible-galaxy/openstack-nova_conductor.git ../openstack-nova_conductor
+  - git clone --depth=1 https://github.com/openstack-ansible-galaxy/openstack-glance.git ../openstack-glance
+  - git clone --depth=1 https://github.com/openstack-ansible-galaxy/openstack-nova_api.git ../openstack-nova_api
 
 
 script:

--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ Role Variables
 | `keystone_hostname` | `localhost` | Hostname/IP address where the keystone service runs ||
 | `keystone_port` | `5000` | Keystone service port ||
 | `keystone_protocol` | `http` | Desired keystone protocol (http/https) ||
-| `rabbit_hostname` | `localhost` | Hostname/IP address where the RabbitMQ service runs ||
-| `rabbit_username` | `rabbit_username_default` | RabbitMQ username for neutron ||
-| `rabbit_pass` | `rabbit_pass_default` | RabbitMQ password for neutron ||
+| `neutron_rabbit_hostname` | `localhost` | Hostname/IP address where the RabbitMQ service runs ||
+| `neutron_rabbit_username` | `rabbit_username_default` | RabbitMQ username for neutron ||
+| `neutron_rabbit_pass` | `rabbit_pass_default` | RabbitMQ password for neutron ||
+| `neutron_rabbit_virtual_host` | `/` | RabbitMQ virtual host ||
+| `neutron_rabbit_retry_interval` | `1` | Frequency to retry connecting to RabbitMQ ||
+| `neutron_rabbit_hosts` | `$rabbit_host:$rabbit_port` | RabbitMQ HA Cluster host:port pairs ||
+| `neutron_rabbit_ha_queues` | `False` | Use HA queues in RabbitMQ (x-ha-policy:all) ||
 
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Role Variables
 | `keystone_port` | `5000` | Keystone service port ||
 | `keystone_protocol` | `http` | Desired keystone protocol (http/https) ||
 | `neutron_rabbit_hostname` | `localhost` | Hostname/IP address where the RabbitMQ service runs ||
-| `neutron_rabbit_username` | `rabbit_username_default` | RabbitMQ username for neutron ||
-| `neutron_rabbit_pass` | `rabbit_pass_default` | RabbitMQ password for neutron ||
+| `neutron_rabbit_userid` | `rabbit_username_default` | RabbitMQ username for neutron ||
+| `neutron_rabbit_password` | `rabbit_pass_default` | RabbitMQ password for neutron ||
 | `neutron_rabbit_virtual_host` | `/` | RabbitMQ virtual host ||
 | `neutron_rabbit_retry_interval` | `1` | Frequency to retry connecting to RabbitMQ ||
 | `neutron_rabbit_hosts` | `$rabbit_host:$rabbit_port` | RabbitMQ HA Cluster host:port pairs ||

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,13 @@
 neutron_server_hostname: localhost
 neutron_user: neutron
 neutron_pass: neutron_pass_default
+neutron_bind_host: 0.0.0.0
 neutron_port: 9696
 neutron_protocol: http
 neutron_log_dir: /var/log/neutron
+neutron_log_debug: False
+neutron_log_verbose: False
+neutron_api_paste: /usr/share/neutron/api-paste.ini
 
 # Keystone
 keystone_admin_port: 35357
@@ -43,6 +47,12 @@ nova_admin_tenant_id: false
 neutron_database_url: "sqlite:////var/lib/neutron/neutron.sqlite"
 
 # RabbitMQ
-rabbit_hostname: localhost
-rabbit_username: rabbit_username_default
-rabbit_pass: rabbit_pass_default
+neutron_rabbit_hostname: localhost
+neutron_rabbit_username: rabbit_username_default
+neutron_rabbit_pass: rabbit_pass_default
+neutron_rabbit_virtual_host: /
+neutron_rabbit_retry_interval: 1
+neutron_rabbit_port: 5672
+neutron_rabbit_hosts: "{{ neutron_rabbit_hostname }}:{{ neutron_rabbit_port }}"
+neutron_rabbit_ha_queues: False
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,8 +48,8 @@ neutron_database_url: "sqlite:////var/lib/neutron/neutron.sqlite"
 
 # RabbitMQ
 neutron_rabbit_hostname: localhost
-neutron_rabbit_username: rabbit_username_default
-neutron_rabbit_pass: rabbit_pass_default
+neutron_rabbit_userid: rabbit_username_default
+neutron_rabbit_password: rabbit_pass_default
 neutron_rabbit_virtual_host: /
 neutron_rabbit_retry_interval: 1
 neutron_rabbit_port: 5672

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,10 +37,10 @@ keystone_protocol: http
 
 # Nova
 nova_api_hostname: localhost
-nova_user: nova
-nova_pass: nova_pass_default
-nova_port: 8774
-nova_protocol: http
+nova_api_user: nova
+nova_api_pass: nova_pass_default
+nova_api_port: 8774
+nova_api_protocol: http
 nova_admin_tenant_id: false
 
 # Database

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ neutron_protocol: http
 neutron_log_dir: /var/log/neutron
 neutron_log_debug: False
 neutron_log_verbose: False
-neutron_api_paste: /usr/share/neutron/api-paste.ini
+neutron_api_paste: /etc/neutron/api-paste.ini
 
 # Keystone
 keystone_admin_port: 35357

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,6 @@ neutron_protocol: http
 neutron_log_dir: /var/log/neutron
 neutron_log_debug: False
 neutron_log_verbose: False
-neutron_api_paste: /etc/neutron/api-paste.ini
 
 # Keystone
 keystone_admin_port: 35357

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,9 +17,6 @@
 # limitations under the License.
 #
 
-- name: Reload Neutron server
-  service: name=neutron-server state=reloaded
-
 - name: Restart Neutron server
   service: name=neutron-server state=restarted
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,7 +18,7 @@
 #
 
 - name: Restart Neutron server
-  service: name=neutron-server state=restarted
+  service: name=neutron-server state=restarted enabled=yes
 
 - name: Start Neutron server
-  service: name=neutron-server state=started
+  service: name=neutron-server state=started enabled=yes

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -66,10 +66,10 @@
       value:    "{{ neutron_rabbit_hostname }}"
     - section:  DEFAULT
       option:   rabbit_userid
-      value:    "{{ neutron_rabbit_username }}"
+      value:    "{{ neutron_rabbit_userid }}"
     - section:  DEFAULT
       option:   rabbit_password
-      value:    "{{ neutron_rabbit_pass }}"
+      value:    "{{ neutron_rabbit_password }}"
     - section:  DEFAULT
       option:   rabbit_virtual_host
       value:    "{{ neutron_rabbit_virtual_host }}"

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -46,23 +46,42 @@
       option:   connection
       value:    "{{ neutron_database_url }}"
     - section:  DEFAULT
+      option:   bind_host
+      value:    "{{ neutron_bind_host }}"
+    - section:  DEFAULT
       option:   bind_port
       value:    "{{ neutron_port }}"
     - section:  DEFAULT
       option:   auth_strategy
       value:    keystone
     - section:  DEFAULT
+      option:   api_paste_config
+      value:    "{{ neutron_api_paste }}"
+    # RabbitMQ
+    - section:  DEFAULT
       option:   rpc_backend
       value:    neutron.openstack.common.rpc.impl_kombu
     - section:  DEFAULT
       option:   rabbit_host
-      value:    "{{ rabbit_hostname }}"
+      value:    "{{ neutron_rabbit_hostname }}"
     - section:  DEFAULT
       option:   rabbit_userid
-      value:    "{{ rabbit_username }}"
+      value:    "{{ neutron_rabbit_username }}"
     - section:  DEFAULT
       option:   rabbit_password
-      value:    "{{ rabbit_pass }}"
+      value:    "{{ neutron_rabbit_pass }}"
+    - section:  DEFAULT
+      option:   rabbit_virtual_host
+      value:    "{{ neutron_rabbit_virtual_host }}"
+    - section:  DEFAULT
+      option:   rabbit_retry_interval
+      value:    "{{ neutron_rabbit_retry_interval }}"
+    - section:  DEFAULT
+      option:   rabbit_hosts
+      value:    "{{ neutron_rabbit_hosts }}"
+    - section:  DEFAULT
+      option:   rabbit_ha_queues
+      value:    "{{ neutron_rabbit_ha_queues }}"
     - section:  DEFAULT
       option:   notify_nova_on_port_status_changes
       value:    True
@@ -96,6 +115,12 @@
     - section:  DEFAULT
       option:   log_dir
       value:    "{{ neutron_log_dir }}"
+    - section:  DEFAULT
+      option:   log_debug
+      value:    "{{ neutron_log_debug }}"
+    - section:  DEFAULT
+      option:   log_verbose
+      value:    "{{ neutron_log_verbose }}"
     - section:  keystone_authtoken
       option:   auth_uri
       value:    "{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_port }}"
@@ -118,4 +143,4 @@
       option:   admin_password
       value:    "{{ neutron_pass }}"
   notify:
-    - Reload Neutron server
+    - Restart Neutron server

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -46,6 +46,9 @@
       option:   connection
       value:    "{{ neutron_database_url }}"
     - section:  DEFAULT
+      option:   api_paste_config
+      value:    "{{ neutron_api_paste }}"
+    - section:  DEFAULT
       option:   bind_host
       value:    "{{ neutron_bind_host }}"
     - section:  DEFAULT

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Set service Facts
+  set_fact: neutron_api_paste='/etc/neutron/api-paste.ini'
+  when: ansible_os_family == 'Debian'
+
+- name: Set service Facts
+  set_fact: neutron_api_paste='/usr/share/neutron/api-paste.ini'
+  when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
 
 - meta: flush_handlers
 
+- include: facts.yml
 - include: packages.yml
 - include: configuration.yml
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -82,7 +82,7 @@
       keystone_hostname: 127.0.0.1
       neutron_rabbit_hostname: 127.0.0.1
       neutron_rabbit_username: "guest"
-      neutron__rabbit_pass: "guest"
+      neutron_rabbit_pass: "guest"
       nova_protocol: "http"
       nova_api_hostname: 127.0.0.1
       nova_port: "8774"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,7 +3,7 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - role: dguerri.openstack-keystone
+    - role: openstack-keystone
       keystone_admin_bind_host: 127.0.0.1
       keystone_bind_host: 127.0.0.1
       keystone_admin_token: "os token"
@@ -46,29 +46,29 @@
           internal_url: "http://127.0.0.1:9696/"
           admin_url: "http://127.0.0.1:9696/"
 
-    - role: dguerri.openstack-glance
+    - role: openstack-glance
       glance_hostname: 127.0.0.1
       glance_pass: "glance password"
       keystone_hostname: 127.0.0.1
-      rabbit_hostname: 127.0.0.1
-      rabbit_username: guest
-      rabbit_pass: "guest"
+      glance_rabbit_hostname: 127.0.0.1
+      glance_rabbit_username: guest
+      glance_rabbit_pass: "guest"
 
-    - role: dguerri.openstack-nova_conductor
+    - role: openstack-nova_conductor
       my_ip: "127.0.0.1"
       keystone_hostname: "127.0.0.1"
-      rabbit_hostname: "127.0.0.1"
-      rabbit_username: "guest"
-      rabbit_pass: "guest"
+      nova_conductor_rabbit_hostname: "127.0.0.1"
+      nova_conductor_rabbit_username: "guest"
+      nova_conductor_rabbit_pass: "guest"
 
-    - role: dguerri.openstack-nova_api
+    - role: openstack-nova_api
       my_ip: "127.0.0.1"
       keystone_hostname: "127.0.0.1"
-      rabbit_hostname: "127.0.0.1"
-      rabbit_username: "guest"
-      rabbit_pass: "guest"
+      nova_api_rabbit_hostname: "127.0.0.1"
+      nova_api_rabbit_username: "guest"
+      nova_api_rabbit_pass: "guest"
       metadata_secret: "metadata_secret"
-      nova_pass: "nova password"
+      nova_api_pass: "nova password"
       glance_hostname: "127.0.0.1"
       neutron_host: "127.0.0.1"
       neutron_pass: "neutron password"
@@ -80,9 +80,9 @@
       neutron_pass: "neutron password"
       neutron_port: "9696"
       keystone_hostname: 127.0.0.1
-      rabbit_hostname: 127.0.0.1
-      rabbit_username: "guest"
-      rabbit_pass: "guest"
+      neutron_rabbit_hostname: 127.0.0.1
+      neutron_rabbit_username: "guest"
+      neutron__rabbit_pass: "guest"
       nova_protocol: "http"
       nova_api_hostname: 127.0.0.1
       nova_port: "8774"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -51,8 +51,8 @@
       glance_pass: "glance password"
       keystone_hostname: 127.0.0.1
       glance_rabbit_hostname: 127.0.0.1
-      glance_rabbit_username: guest
-      glance_rabbit_pass: "guest"
+      glance_rabbit_userid: guest
+      glance_rabbit_password: "guest"
 
     - role: openstack-nova_conductor
       my_ip: "127.0.0.1"


### PR DESCRIPTION
This matches the convention used by the other services.
Adds support for HA queues and adds debug/verbose logging
Makes the bind_host configurable, replaces reload with
restart for systemd compatibility. Adds default api-paste
